### PR TITLE
VS2019 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,9 @@
 version: 4.2.{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 environment:
   matrix:
-    - PlatformToolset: VS17
+    - PlatformToolset: VS19
     
 platform:
     - Any CPU
@@ -20,7 +20,7 @@ install:
     - if "%platform%"=="Any CPU" set archi=x86
     - if "%platform%"=="Any CPU" set platform_input=Any CPU
 
-    - if "%PlatformToolset%"=="VS17" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
+    - if "%PlatformToolset%"=="VS19" call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %archi%
 
     - cd "%APPVEYOR_BUILD_FOLDER%\source"
     - nuget restore "%APPVEYOR_BUILD_FOLDER%"\source\JsParser.VsExtension\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\source\packages
@@ -72,5 +72,5 @@ deploy:
     force_update: true
     on:
         appveyor_repo_tag: true
-        PlatformToolset: VS17
+        PlatformToolset: VS19
         configuration: Release

--- a/source/JsParser.NppPlugin/DllExport/DllExportAttribute.cs
+++ b/source/JsParser.NppPlugin/DllExport/DllExportAttribute.cs
@@ -1,4 +1,4 @@
-﻿// NPP plugin platform for .Net v0.93.96 by Kasper B. Graversen etc.
+﻿// NPP plugin platform for .Net v0.94.00 by Kasper B. Graversen etc.
 using System;
 using System.Runtime.InteropServices;
 

--- a/source/JsParser.NppPlugin/DllExport/NppPlugin.DllExport.targets
+++ b/source/JsParser.NppPlugin/DllExport/NppPlugin.DllExport.targets
@@ -5,6 +5,11 @@
   <Target Name="AfterBuild"
           DependsOnTargets="GetFrameworkPaths"
           >
+    <PropertyGroup>
+		<!-- LibToolPath is optional - it's needed to debug C++, but you can still debug the C# code without it
+			If you don't have the C++ toolchain installed this is missing, but then you can't' debug C++ anyway -->
+        <LibToolPath Condition="Exists('$(DevEnvDir)\..\..\VC\bin')">$(DevEnvDir)\..\..\VC\bin</LibToolPath>
+    </PropertyGroup>
     <DllExportTask Platform="$(Platform)"
                    PlatformTarget="$(PlatformTarget)"
                    CpuType="$(CpuType)"
@@ -15,8 +20,9 @@
                    KeyContainer="$(KeyContainerName)$(AssemblyKeyContainerName)"
                    KeyFile="$(KeyOriginatorFile)"
                    ProjectDirectory="$(MSBuildProjectDirectory)"
-                   InputFileName="$(ProjectDir)build\JsMapParser.NppPlugin.dll"
+                   InputFileName="$(TargetPath)"
                    FrameworkPath="$(TargetedFrameworkDir);$(TargetFrameworkDirectory)"
+                   LibToolPath="$(LibToolPath)"
                    LibToolDllPath="$(DevEnvDir)"
                    SdkPath="$(SDK40ToolsPath)"/>
   </Target>

--- a/source/JsParser.VsExtension/Infrastructure/VS2010CodeProvider.cs
+++ b/source/JsParser.VsExtension/Infrastructure/VS2010CodeProvider.cs
@@ -9,9 +9,9 @@ using System.Threading;
 
 namespace JsParser.VsExtension.Infrastructure
 {
-	public class VS2010CodeProvider: ICodeProvider
+	public class VS2010CodeProvider : ICodeProvider
 	{
-		private Document _activeDocument;
+		private readonly Document _activeDocument;
 
 		public VS2010CodeProvider(Document activeDocument)
 		{

--- a/source/JsParser.VsExtension/JsParser.Package.cs
+++ b/source/JsParser.VsExtension/JsParser.Package.cs
@@ -47,7 +47,6 @@ namespace JsParser.VsExtension
     {
         private JsParserService _jsParserService;
         private DocumentEvents _documentEvents;
-        private SolutionEvents _solutionEvents;
         private WindowEvents _windowEvents;
         private static JsParserToolWindowManager _jsParserToolWindowManager;
 
@@ -119,11 +118,10 @@ namespace JsParser.VsExtension
             var dte = (DTE) GetService(typeof (DTE));
             Events events = dte.Events;
             _documentEvents = events.get_DocumentEvents(null);
-            _solutionEvents = events.SolutionEvents;
             _windowEvents = events.get_WindowEvents(null);
-            _documentEvents.DocumentSaved += documentEvents_DocumentSaved;
-            _documentEvents.DocumentOpened += documentEvents_DocumentOpened;
-            _windowEvents.WindowActivated += windowEvents_WindowActivated;
+            _documentEvents.DocumentSaved += DocumentEvents_DocumentSaved;
+            _documentEvents.DocumentOpened += DocumentEvents_DocumentOpened;
+            _windowEvents.WindowActivated += WindowEvents_WindowActivated;
 
             _jsParserToolWindowManager = new JsParserToolWindowManager(_jsParserService, () =>
             {
@@ -165,7 +163,7 @@ namespace JsParser.VsExtension
             Microsoft.VisualStudio.ErrorHandler.ThrowOnFailure(windowFrame.Show());
         }
 
-        private void windowEvents_WindowActivated(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus)
+        private void WindowEvents_WindowActivated(EnvDTE.Window gotFocus, EnvDTE.Window lostFocus)
         {
             if (gotFocus == null
                 || gotFocus.Kind != "Document"
@@ -178,7 +176,7 @@ namespace JsParser.VsExtension
             _jsParserToolWindowManager.CallParserForDocument(new VS2010CodeProvider(gotFocus.Document));
         }
 
-        private void documentEvents_DocumentSaved(Document doc)
+        private void DocumentEvents_DocumentSaved(Document doc)
         {
             if (doc.ActiveWindow != null
                 && doc.ActiveWindow.Left == 0
@@ -191,7 +189,7 @@ namespace JsParser.VsExtension
             _jsParserToolWindowManager.CallParserForDocument(new VS2010CodeProvider(doc));
         }
 
-        private void documentEvents_DocumentOpened(Document doc)
+        private void DocumentEvents_DocumentOpened(Document doc)
         {
             _jsParserToolWindowManager.CallParserForDocument(new VS2010CodeProvider(doc));
         }

--- a/source/JsParser.VsExtension/Resources/Resources.resx
+++ b/source/JsParser.VsExtension/Resources/Resources.resx
@@ -121,6 +121,6 @@
     <value>Can not create tool window.</value>
   </data>
   <data name="ToolWindowTitle" xml:space="preserve">
-    <value>Javascript Map Parser</value>
+    <value>JavaScript Map Parser</value>
   </data>
 </root>

--- a/source/JsParser.VsExtension/UI/ErrorsNotificationControl.xaml.cs
+++ b/source/JsParser.VsExtension/UI/ErrorsNotificationControl.xaml.cs
@@ -85,9 +85,9 @@ namespace JsParser.VsExtension.UI
         {
             _codeProvider = args.Code;
 
-            if (args is JsParserErrorsNotificationArgs)
+            if (args is JsParserErrorsNotificationArgs args1)
             {
-                SetErrors(((JsParserErrorsNotificationArgs)args));
+                SetErrors(args1);
                 return;
             }
         }

--- a/source/JsParser.VsExtension/UI/JSParserToolWindow.cs
+++ b/source/JsParser.VsExtension/UI/JSParserToolWindow.cs
@@ -34,7 +34,7 @@ namespace JsParser.VsExtension.UI
     [Guid(GuidList.guidToolWindowPersistanceString)]
     public class JsParserToolWindow : ToolWindowPane, IJsParserToolWindow
     {
-        private NavigationTreeView _navigationTreeView;
+        private readonly NavigationTreeView _navigationTreeView;
 
         public NavigationTreeView NavigationTreeView
         {


### PR DESCRIPTION
- used VS2019 for appveyor.yml
- updated DllExport/NppPlugin.DllExport.targets for build with VS2019
- fixed some VS warnings